### PR TITLE
✨feat: expand size of UDP buffer

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ func NewZoneNsResolver() *ZoneNsResolver {
 		},
 		&dns.Client{
 			ReadTimeout: DefaultTimeout,
+			UDPSize:     4096,
 		},
 	}
 }


### PR DESCRIPTION
Hi👋, thanks for your open source, it's really convenient for me to develop.
While using the program, I often encountered dns queries failing due to the small size of the UDP buffer.
This problem also caused several [issues](https://github.com/miekg/dns/issues/214) with the DNS library.
To avoid this, I added code to increase the size of the UDP buffer.

Errors I encountered
![image](https://github.com/DNSSpy/zone-nameservers/assets/102205852/fd1187a6-ad11-403f-ab95-1f1b307efe54)
